### PR TITLE
Add simple color formatter

### DIFF
--- a/devpy/__main__.py
+++ b/devpy/__main__.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
     @click.pass_context
     def group(ctx):
         ctx.meta["config"] = DotDict(toml_config)
+        ctx.show_default = True
 
     config_cmds = config["commands"]
     # Commands can be provided as a list, or as a dictionary

--- a/devpy/__main__.py
+++ b/devpy/__main__.py
@@ -10,6 +10,10 @@ from . import cmds
 from .cmds import util
 from .cmds import *
 from .sectioned_help import SectionedHelpGroup
+from .color_format import ColorHelpFormatter
+
+
+click.Context.formatter_class = ColorHelpFormatter
 
 
 class DotDict(dict):

--- a/devpy/cmds/util.py
+++ b/devpy/cmds/util.py
@@ -9,9 +9,9 @@ import click
 
 def run(cmd, cwd=None, replace=False, sys_exit=True, output=True, *args, **kwargs):
     if cwd:
-        print(f"$ cd {cwd}", flush=True)
+        click.secho(f"$ cd {cwd}", dim=True)
         os.chdir(cwd)
-    print(f"$ {shlex.join(cmd)}", flush=True)
+    click.secho(f"$ {shlex.join(cmd)}", dim=True)
 
     if output is False:
         output_kwargs = {"stdout": subprocess.PIPE, "stderr": subprocess.STDOUT}

--- a/devpy/color_format.py
+++ b/devpy/color_format.py
@@ -1,0 +1,33 @@
+import re
+
+import click
+
+
+class ColorHelpFormatter(click.formatting.HelpFormatter):
+    def write_heading(self, heading):
+        super().write_heading(click.style(heading, dim=True))
+
+    def write_dl(self, items):
+        default_style = click.style("", bold=True, fg="cyan", reset=False)
+        reset_style = click.style("", reset=True)
+        style_rules = {
+            " [A-Z]+": {"bold": True, "fg": "yellow"},
+            r"\-[a-z]{1}(?=[ ,]{1})": {"fg": "green"},
+        }
+        style_rules = {
+            re.compile(expr): format for (expr, format) in style_rules.items()
+        }
+        for (expr, format) in style_rules.items():
+            items = [
+                (expr.sub(click.style("\\g<0>", **format) + default_style, key), val)
+                for (key, val) in items
+            ]
+        items = [(default_style + key, reset_style + val) for (key, val) in items]
+        super().write_dl(items)
+
+    def write_usage(self, prog, args="", prefix=None):
+        super().write_usage(
+            click.style(prog, bold=True, fg="white"),
+            args,
+            prefix=click.style("Usage: ", bold=True, fg="yellow"),
+        )

--- a/devpy/color_format.py
+++ b/devpy/color_format.py
@@ -1,33 +1,51 @@
 import re
+import shutil
 
 import click
 
 
+class RegexpFormatter:
+    def __init__(self, rules, default=None):
+        if default is None:
+            default = {}
+        self.rules = {re.compile(expr): format for (expr, format) in rules.items()}
+        self.default_style = click.style("", **default, reset=False)
+        self.reset_style = click.style("", reset=True)
+
+    def __call__(self, txt):
+        for (expr, format) in self.rules.items():
+            txt = expr.sub(click.style("\\g<0>", **format) + self.default_style, txt)
+        txt = self.default_style + txt + self.reset_style
+        return txt
+
+
 class ColorHelpFormatter(click.formatting.HelpFormatter):
+    def __init__(self, *args, **kwargs):
+        kwargs["width"] = shutil.get_terminal_size()[0]
+        super().__init__(*args, **kwargs)
+
     def write_heading(self, heading):
         super().write_heading(click.style(heading, dim=True))
 
     def write_dl(self, items):
-        default_style = click.style("", bold=True, fg="cyan", reset=False)
-        reset_style = click.style("", reset=True)
-        style_rules = {
-            " [A-Z]+": {"bold": True, "fg": "yellow"},
-            r"\-[a-z]{1}(?=[ ,]{1})": {"fg": "green"},
-        }
-        style_rules = {
-            re.compile(expr): format for (expr, format) in style_rules.items()
-        }
-        for (expr, format) in style_rules.items():
-            items = [
-                (expr.sub(click.style("\\g<0>", **format) + default_style, key), val)
-                for (key, val) in items
-            ]
-        items = [(default_style + key, reset_style + val) for (key, val) in items]
+        """Print definition list"""
+        key_fmt = RegexpFormatter(
+            {
+                " [A-Z]+": {"bold": True, "fg": "yellow"},
+                r"\-[a-z]{1}(?=[ ,]{1})": {"fg": "green"},
+            },
+            default={"bold": True, "fg": "cyan"},
+        )
+        val_fmt = RegexpFormatter({r"\[default: .*?\]": {"dim": True}})
+        items = [(key_fmt(key), val_fmt(val)) for (key, val) in items]
         super().write_dl(items)
 
     def write_usage(self, prog, args="", prefix=None):
+        fmt = RegexpFormatter(
+            {r"(?<=\[)[A-Z_]+(?=\])": {"fg": "cyan"}}, default={"bold": True}
+        )
         super().write_usage(
             click.style(prog, bold=True, fg="white"),
-            args,
+            click.style(fmt(args), bold=True),
             prefix=click.style("Usage: ", bold=True, fg="yellow"),
         )

--- a/devpy/sectioned_help.py
+++ b/devpy/sectioned_help.py
@@ -3,7 +3,7 @@ import collections
 
 
 class SectionedHelpGroup(click.Group):
-    """Sections commands into help groups"""
+    """Organize commands as sections"""
 
     def __init__(self, *args, **kwargs):
         self.section_commands = collections.defaultdict(list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ classifiers = [
 ]
 dependencies = [
   "click",
-  "toml"
+  "toml",
+  "colorama"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dependencies = [
   "click",
   "toml",
-  "colorama"
+  "colorama; platform_system == 'Windows'"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This tries to strike a balance between adding some helpful color emphasis, without adding dependencies other than what click would already use (colorama, on Windows).

It's not worth replicating the whole of rich, though, so if we want to do much more colorization we should depend on rich_click instead.

Closes #21 