### PR TITLE
Run `pytest` as `python -m pytest`

### DIFF
--- a/devpy/cmds/_test.py
+++ b/devpy/cmds/_test.py
@@ -31,4 +31,7 @@ def test(build_dir, pytest_args):
     set_pythonpath(build_dir)
 
     print(f'$ export PYTHONPATH="{site_path}"')
-    run(["pytest", f"--rootdir={site_path}"] + list(pytest_args), cwd=site_path)
+    run(
+        ["python", "-m", "pytest", f"--rootdir={site_path}"] + list(pytest_args),
+        cwd=site_path,
+    )


### PR DESCRIPTION
Sometimes, with multiple versions of Python, `pytest` on the path may correspond to a different version of Python.