### PR TITLE
Revert "Match current Python version for site-packages (#29)"

### DIFF
--- a/devpy/cmds/util.py
+++ b/devpy/cmds/util.py
@@ -36,10 +36,9 @@ def get_config():
 
 
 def get_site_packages(build_dir):
-    X, Y = sys.version_info.major, sys.version_info.minor
     for root, dirs, files in os.walk(install_dir(build_dir)):
         for subdir in dirs:
-            if subdir == "site-packages" and root.endswith(f"python{X}.{Y}"):
+            if subdir == "site-packages":
                 return os.path.abspath(os.path.join(root, subdir))
 
 


### PR DESCRIPTION
This reverts commit bf9a87ed46b193d76ed190644d74f7ef491eb6ca, reversing changes made to 0032e3d2c79ffb3df1467ccfe29ed4a056911b8f.

This push to devpy broke site-path detection on Windows.

You'll see the previous PR looks for python3.10/site-packages, but under Windows they just put it under /Lib/site-packages or something.