### PR TITLE
Fix support for python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,15 @@ permissions:
 
 jobs:
   test_devpy:
+    strategy:
+      matrix:
+        python_version: ['3.7', '3.11']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python_version }}
       - name: Install
         run: |
           pip install -e .

--- a/devpy/__main__.py
+++ b/devpy/__main__.py
@@ -1,3 +1,4 @@
+import collections
 import os
 import sys
 import importlib
@@ -16,21 +17,15 @@ from .color_format import ColorHelpFormatter
 click.Context.formatter_class = ColorHelpFormatter
 
 
-class DotDict(dict):
+class DotDict(collections.UserDict):
     def __getitem__(self, key):
-        subitem = self
+        subitem = self.data
         for subkey in key.split("."):
             try:
-                subitem = dict.__getitem__(subitem, subkey)
+                subitem = subitem[subkey]
             except KeyError:
                 raise KeyError(f"`{key}` not found in configuration") from None
         return subitem
-
-    def get(self, key, default=None, /):
-        try:
-            return self.__getitem__(key)
-        except KeyError:
-            return default
 
 
 if __name__ == "__main__":

--- a/devpy/cmds/util.py
+++ b/devpy/cmds/util.py
@@ -11,7 +11,8 @@ def run(cmd, cwd=None, replace=False, sys_exit=True, output=True, *args, **kwarg
     if cwd:
         click.secho(f"$ cd {cwd}", bold=True, fg="bright_blue")
         os.chdir(cwd)
-    click.secho(f"$ {shlex.join(cmd)}", bold=True, fg="bright_blue")
+    cmdstr = ' '.join(shlex.quote(arg) for arg in cmd)
+    click.secho(f"$ {cmdstr}", bold=True, fg="bright_blue")
 
     if output is False:
         output_kwargs = {"stdout": subprocess.PIPE, "stderr": subprocess.STDOUT}


### PR DESCRIPTION
As observed in https://github.com/qpv-research-group/solcore5/issues/238#issuecomment-1339626818

pyproject.toml lists support for 3.7 as a minimum. This is reasonable -- it will still be supported for another 6 months, and projects using devpy will frequently want to support that version too. As an infrastructure package, there's a strong rationale to be lenient in version support.

The snag is that 3.7 is not tested in CI, and it turns out it doesn't work. The practical minimum is 3.8 but both of the incompatibilities are trivially fixed -- and one of them is actually better code when using the fix.