### PR TITLE
Prefer site-packages paths with Python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,10 @@ jobs:
         run: |
           pip install -e .
           pip install pytest meson-python ninja
-      - name: Test
+      - name: Library tests
+        run: |
+          PYTHONPATH=. pytest --pyargs devpy
+      - name: Functional tests
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'
         env:
           TERM: xterm-256color

--- a/devpy/__main__.py
+++ b/devpy/__main__.py
@@ -103,4 +103,8 @@ if __name__ == "__main__":
 
             group.add_command(commands[cmd], section=section)
 
-    group()
+    try:
+        group()
+    except Exception as e:
+        print(f"{e}; aborting.")
+        sys.exit(1)

--- a/devpy/cmds/_shell.py
+++ b/devpy/cmds/_shell.py
@@ -4,7 +4,7 @@ import copy
 
 import click
 
-from .util import run, get_config, get_site_packages, set_pythonpath
+from .util import run, get_config, set_pythonpath
 
 
 @click.command()

--- a/devpy/cmds/util.py
+++ b/devpy/cmds/util.py
@@ -36,10 +36,20 @@ def get_config():
 
 
 def get_site_packages(build_dir):
+    candidate_paths = []
     for root, dirs, files in os.walk(install_dir(build_dir)):
         for subdir in dirs:
             if subdir == "site-packages":
-                return os.path.abspath(os.path.join(root, subdir))
+                candidate_paths.append(os.path.abspath(os.path.join(root, subdir)))
+
+    if len(candidate_paths) == 0:
+        return None
+
+    # Prefer paths with current Python version in them
+    X, Y = sys.version_info.major, sys.version_info.minor
+    candidate_paths = sorted(candidate_paths, key=lambda p: f"python{X}.{Y}" in p)
+    candidate_paths = sorted(candidate_paths, key=lambda p: f"python{X}" in p)
+    return candidate_paths[-1]
 
 
 def set_pythonpath(build_dir):

--- a/devpy/cmds/util.py
+++ b/devpy/cmds/util.py
@@ -50,19 +50,25 @@ def get_site_packages(build_dir):
         # We have a system that uses `python3.X/site-packages` or `python3.X/dist-packages`
         site_packages = [p for p in candidate_paths if f"python{X}.{Y}" in p]
         if len(site_packages) == 0:
-            print(f"No site-packages found in `{build_dir}` for Python {X}.{Y}")
-            sys.exit(1)
+            raise FileNotFoundError(
+                "No site-packages found in `{build_dir}` for Python {X}.{Y}"
+            )
         else:
             site_packages = site_packages[0]
     else:
         # A naming scheme that does not encode the Python major/minor version is used, so return
-        # the first site-packages path found
-        if len(candidate_paths) != 0:
+        # whatever site-packages path was found
+        if len(candidate_paths) > 1:
+            raise FileNotFoundError(
+                "Multiple `site-packages` found, but cannot use Python version to disambiguate"
+            )
+        elif len(candidate_paths) == 1:
             site_packages = candidate_paths[0]
 
     if site_packages is None:
-        print(f"No `site-packages` directory found under {build_dir}; aborting")
-        sys.exit(1)
+        raise FileNotFoundError(
+            f"No `site-packages` or `dist-packages` found under {build_dir}"
+        )
 
     return site_packages
 

--- a/devpy/tests/test_builtin_cmds.py
+++ b/devpy/tests/test_builtin_cmds.py
@@ -1,5 +1,0 @@
-from test_util import run_devpy
-
-
-def test_build():
-    run_devpy(["build"])

--- a/devpy/tests/test_util.py
+++ b/devpy/tests/test_util.py
@@ -1,10 +1,84 @@
-import subprocess
+import tempfile
+import sys
+import os
+from os.path import join as pjoin
+
+import pytest
+
+from devpy import util
 
 
-def run_devpy(extra_args):
-    p = subprocess.run(["python", "-m", "devpy"] + extra_args, capture_output=True)
-    if p.returncode != 0:
-        print(p.stdout.decode("utf-8"), end="")
-        print(p.stderr.decode("utf-8"), end="")
-        raise RuntimeError("Failed to execute dev.py; see printed stdout/stderr")
-    return p
+def make_paths(root, paths):
+    for p in paths:
+        os.makedirs(pjoin(root, p.lstrip("/")))
+
+
+def test_path_discovery():
+    version = sys.version_info
+    X, Y = version.major, version.minor
+
+    # With multiple site-packages, choose the one that
+    # matches the current Python version
+    with tempfile.TemporaryDirectory() as d:
+        build_dir = pjoin(d, "build")
+        install_dir = pjoin(d, "build-install")
+        make_paths(
+            install_dir,
+            [
+                f"/usr/lib64/python{X}.{Y}/site-packages/",
+                f"/usr/lib64/python{X}.{Y + 1}/site-packages/",
+                f"/usr/lib64/python{X}.{Y + 2}/site-packages/",
+            ],
+        )
+        util.get_site_packages(build_dir)
+
+    # Debian uses dist-packages
+    with tempfile.TemporaryDirectory() as d:
+        build_dir = pjoin(d, "build")
+        install_dir = pjoin(d, "build-install")
+        make_paths(
+            install_dir,
+            [
+                f"/usr/lib64/python{X}.{Y}/dist-packages/",
+            ],
+        )
+        util.get_site_packages(build_dir)
+
+    # If there is no version information in site-packages,
+    # use whatever site-packages can be found
+    with tempfile.TemporaryDirectory() as d:
+        build_dir = pjoin(d, "build")
+        install_dir = pjoin(d, "build-install")
+        make_paths(install_dir, [f"/Python3/site-packages/"])
+        util.get_site_packages(build_dir)
+
+    # Raise if no site-package directory present
+    with tempfile.TemporaryDirectory() as d:
+        build_dir = pjoin(d, "build")
+        with pytest.raises(FileNotFoundError):
+            util.get_site_packages(build_dir)
+
+    # If there are multiple site-package paths, but without version information,
+    # refuse the temptation to guess
+    with tempfile.TemporaryDirectory() as d:
+        build_dir = pjoin(d, "build")
+        install_dir = pjoin(d, "build-install")
+        make_paths(
+            install_dir, [f"/Python3/x/site-packages/" f"/Python3/y/site-packages"]
+        )
+        with pytest.raises(FileNotFoundError):
+            util.get_site_packages(build_dir)
+
+    # Multiple site-package paths found, but none that matches our Python
+    with tempfile.TemporaryDirectory() as d:
+        build_dir = pjoin(d, "build")
+        install_dir = pjoin(d, "build-install")
+        make_paths(
+            install_dir,
+            [
+                f"/usr/lib64/python{X}.{Y + 1}/site-packages/",
+                f"/usr/lib64/python{X}.{Y + 2}/site-packages/",
+            ],
+        )
+        with pytest.raises(FileNotFoundError):
+            util.get_site_packages(build_dir)

--- a/devpy/tests/test_util.py
+++ b/devpy/tests/test_util.py
@@ -25,12 +25,14 @@ def test_path_discovery():
         make_paths(
             install_dir,
             [
-                f"/usr/lib64/python{X}.{Y}/site-packages/",
-                f"/usr/lib64/python{X}.{Y + 1}/site-packages/",
-                f"/usr/lib64/python{X}.{Y + 2}/site-packages/",
+                f"/usr/lib64/python{X}.{Y}/site-packages",
+                f"/usr/lib64/python{X}.{Y + 1}/site-packages",
+                f"/usr/lib64/python{X}.{Y + 2}/site-packages",
             ],
         )
-        util.get_site_packages(build_dir)
+        assert f"/usr/lib64/python{X}.{Y}/site-packages" in util.get_site_packages(
+            build_dir
+        )
 
     # Debian uses dist-packages
     with tempfile.TemporaryDirectory() as d:
@@ -39,18 +41,20 @@ def test_path_discovery():
         make_paths(
             install_dir,
             [
-                f"/usr/lib64/python{X}.{Y}/dist-packages/",
+                f"/usr/lib64/python{X}.{Y}/dist-packages",
             ],
         )
-        util.get_site_packages(build_dir)
+        assert f"/usr/lib64/python{X}.{Y}/dist-packages" in util.get_site_packages(
+            build_dir
+        )
 
     # If there is no version information in site-packages,
     # use whatever site-packages can be found
     with tempfile.TemporaryDirectory() as d:
         build_dir = pjoin(d, "build")
         install_dir = pjoin(d, "build-install")
-        make_paths(install_dir, [f"/Python3/site-packages/"])
-        util.get_site_packages(build_dir)
+        make_paths(install_dir, ["/Python3/site-packages"])
+        assert "/Python3/site-packages" in util.get_site_packages(build_dir)
 
     # Raise if no site-package directory present
     with tempfile.TemporaryDirectory() as d:
@@ -64,7 +68,7 @@ def test_path_discovery():
         build_dir = pjoin(d, "build")
         install_dir = pjoin(d, "build-install")
         make_paths(
-            install_dir, [f"/Python3/x/site-packages/" f"/Python3/y/site-packages"]
+            install_dir, [f"/Python3/x/site-packages", f"/Python3/y/site-packages"]
         )
         with pytest.raises(FileNotFoundError):
             util.get_site_packages(build_dir)
@@ -76,8 +80,8 @@ def test_path_discovery():
         make_paths(
             install_dir,
             [
-                f"/usr/lib64/python{X}.{Y + 1}/site-packages/",
-                f"/usr/lib64/python{X}.{Y + 2}/site-packages/",
+                f"/usr/lib64/python{X}.{Y + 1}/site-packages",
+                f"/usr/lib64/python{X}.{Y + 2}/site-packages",
             ],
         )
         with pytest.raises(FileNotFoundError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,3 @@ include = ["devpy*"]
 filterwarnings = [
   "ignore:cannot collect 'test' because it is not a function:",
 ]
-
-[tool.devpy]
-package = 'devpy'
-
-[tool.devpy.commands]
-# If you don't need sections, you can also provide a list of commands under [tool.devpy]:
-#
-# commands = ["devpy.build", "devpy.test", "devpy.shell", "devpy.ipython", "devpy.python", "custom/cmds.py:example"]
-
-"Build" = ["devpy.build", "devpy.test"]
-"Environments" = ["devpy.shell", "devpy.ipython", "devpy.python"]
-"Extensions" = ["example_pkg/.devpy/cmds.py:example"]


### PR DESCRIPTION
On Linux, you get python3.6/site-packages or python3/site-packages. This helps to ambiguate these paths for different versions of Python.

On Windows, it is typically \usr\Lib\site-packages, so we cannot rely on the version being present.