### PR TITLE
DOC: add some hints to build, test

### DIFF
--- a/devpy/cmds/_build.py
+++ b/devpy/cmds/_build.py
@@ -18,12 +18,16 @@ from .util import run, install_dir
 def build(build_dir, meson_args, jobs=None, clean=False, verbose=False):
     """🔧 Build package with Meson/ninja and install
 
-    MESON_ARGS are passed through directly to pytest, e.g.:
+    MESON_ARGS are passed through e.g.:
 
     ./dev.py build -- -Dpkg_config_path=/lib64/pkgconfig
 
     The package is installed to BUILD_DIR-install
 
+    By default builds for release, to be able to use a debugger set CFLAGS
+    appropriately. For example, for linux use
+
+    CFLAGS="-O0 -g" ./dev.py build
     """
     build_dir = os.path.abspath(build_dir)
     inst_dir = install_dir(build_dir)

--- a/devpy/cmds/_test.py
+++ b/devpy/cmds/_test.py
@@ -16,6 +16,10 @@ def test(build_dir, pytest_args):
     PYTEST_ARGS are passed through directly to pytest, e.g.:
 
     ./dev.py test -- -v
+
+    By default, runs the full test suite. To skip "slow" tests, run
+
+    ./dev.py test -- -m "not slow"
     """
     cfg = get_config()
 


### PR DESCRIPTION
Some things I found helpful when trying this out
- document that the tests will run "full" by default, and show how to skip slow tests
- document adding CFLAGS for debugging. The meson FAQ seemed to suggest this is best practices, maybe there is a better way?