### PR TITLE
Fix Windows builds: use `meson compile` instead of `ninja`

### DIFF
--- a/devpy/cmds/_build.py
+++ b/devpy/cmds/_build.py
@@ -50,7 +50,7 @@ def build(build_dir, meson_args, jobs=None, clean=False, verbose=False):
         shutil.rmtree(build_dir)
         run(build_cmd)
 
-    run(["ninja", "-C", build_dir])
+    run(["meson", "compile", "-C", build_dir])
     run(
         [
             "meson",

--- a/devpy/cmds/_test.py
+++ b/devpy/cmds/_test.py
@@ -32,6 +32,6 @@ def test(build_dir, pytest_args):
 
     print(f'$ export PYTHONPATH="{site_path}"')
     run(
-        ["python", "-m", "pytest", f"--rootdir={site_path}"] + list(pytest_args),
+        [sys.executable, "-m", "pytest", f"--rootdir={site_path}"] + list(pytest_args),
         cwd=site_path,
     )


### PR DESCRIPTION
Closes #38