### PR TITLE
ENH: Added `doc` build command

### DIFF
--- a/devpy/cmds/__init__.py
+++ b/devpy/cmds/__init__.py
@@ -1,3 +1,4 @@
 from ._build import build
 from ._test import test
 from ._shell import ipython, python, shell
+from ._doc import doc

--- a/devpy/cmds/_doc.py
+++ b/devpy/cmds/_doc.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import click
+from .util import run
+
+
+@click.command()
+@click.option(
+    "-t",
+    "--list-targets",
+    default=False,
+    is_flag=True,
+    help="List doc targets",
+)
+@click.option(
+    "-j",
+    "--parallel",
+    help="Number of parallel jobs",
+    type=int,
+    default=1,
+)
+@click.argument("args", nargs=-1)
+def doc(list_targets, parallel, args):
+    """🔧 Build documentation
+
+    PYTHON is set as sys.executable and number of jobs are passed as SPHINXOPTS
+
+    To set PYTHONPATH, use:
+
+    PYTHONPATH="/usr/lib/python3/dist-packages/" ./dev.py build
+    """
+
+    if list_targets:  # list MAKE targets, remove default target
+        targets = ""
+    else:
+        targets = " ".join(args) if args else "html"
+
+    make_params = [f'PYTHON="{sys.executable}"']
+    if parallel:
+        make_params.append(f'SPHINXOPTS="-j{parallel}"')
+
+    os.chdir("doc")
+    run(["make", *make_params, targets])

--- a/devpy/cmds/meson.build
+++ b/devpy/cmds/meson.build
@@ -1,6 +1,7 @@
 python_sources = [
   '__init__.py',
   '_build.py',
+  '_doc.py'
   '_shell.py',
   '_test.py',
   'util.py'

--- a/example_pkg/pyproject.toml
+++ b/example_pkg/pyproject.toml
@@ -12,6 +12,6 @@ package = 'example_pkg'
 #
 # commands = ["devpy.build", "devpy.test", "devpy.shell", "devpy.ipython", "devpy.python", "custom/cmds.py:example"]
 
-"Build" = ["devpy.build", "devpy.test"]
+"Build" = ["devpy.build", "devpy.test", "devpy.doc"]
 "Environments" = ["devpy.shell", "devpy.ipython", "devpy.python"]
 "Extensions" = [".devpy/cmds.py:example"]


### PR DESCRIPTION
### Changes
Attempting to add `doc` build command to be inline with [what's in SciPy](https://github.com/scipy/scipy/blob/a145242132e6f308f5dabdb9c2e030fdc0702ade/dev.py#L954-L999) today

### Testing
Will add to `example_pkg` soon, but here is NumPy meanwhile:

```sh
~/os/numpy (main*) » python3 dev.py doc -j12                                                                                                                                    ganesh@ganesh-MS-7B86
$ make 'PYTHON="/home/ganesh/os/np-test/bin/python3"' 'SPHINXOPTS="-j12"' html     
# for testing                                                                                    
# @echo installed numpy 5f04e748b8 matches git version 5f04e748b8; exit 1                 
mkdir -p build                                                                                   
touch build/generate-stamp                                                                       
mkdir -p build/html build/doctrees                                                               
"/home/ganesh/os/np-test/bin/python3" preprocess.py                                
Unable to find 'Doxygen:doxygen', skip generating C/C++ API from comment blocks.   
LANG=C sphinx-build -b html -WT --keep-going -d build/doctrees  "-j1" source build/html    
Running Sphinx v5.3.0  
....
....
build finished with problems, 3 warnings.
```

### Todo

- [ ] Add to example package
- [ ] Add UT (?)