### PR TITLE
Run `build` before `test` command

### DIFF
--- a/devpy/__main__.py
+++ b/devpy/__main__.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
     @click.pass_context
     def group(ctx):
         ctx.meta["config"] = DotDict(toml_config)
+        ctx.meta["commands"] = ctx.command.section_commands
         ctx.show_default = True
 
     config_cmds = config["commands"]

--- a/devpy/cmds/_build.py
+++ b/devpy/cmds/_build.py
@@ -6,16 +6,13 @@ from .util import run, install_dir
 
 
 @click.command("build")
-@click.option(
-    "--build-dir", default="build", help="Build directory; default is `$PWD/build`"
-)
 @click.option("-j", "--jobs", help="Number of parallel tasks to launch", type=int)
 @click.option("--clean", is_flag=True, help="Clean build directory before build")
 @click.option(
     "-v", "--verbose", is_flag=True, help="Print all build output, even installation"
 )
 @click.argument("meson_args", nargs=-1)
-def build_meson(build_dir, meson_args, jobs=None, clean=False, verbose=False):
+def build_meson(meson_args, jobs=None, clean=False, verbose=False):
     """🔧 Build package with Meson/ninja and install
 
     MESON_ARGS are passed through e.g.:
@@ -29,8 +26,7 @@ def build_meson(build_dir, meson_args, jobs=None, clean=False, verbose=False):
 
     CFLAGS="-O0 -g" ./dev.py build
     """
-    build_dir = os.path.abspath(build_dir)
-    inst_dir = install_dir(build_dir)
+    build_dir = os.path.abspath("build")
     build_cmd = ["meson", "setup", build_dir, "--prefix=/usr"] + list(meson_args)
     flags = []
 
@@ -38,9 +34,9 @@ def build_meson(build_dir, meson_args, jobs=None, clean=False, verbose=False):
         print(f"Removing `{build_dir}`")
         if os.path.isdir(build_dir):
             shutil.rmtree(build_dir)
-        print(f"Removing `{inst_dir}`")
-        if os.path.isdir(inst_dir):
-            shutil.rmtree(inst_dir)
+        print(f"Removing `{install_dir}`")
+        if os.path.isdir(install_dir):
+            shutil.rmtree(install_dir)
 
     if os.path.exists(build_dir):
         flags += ["--reconfigure"]
@@ -63,7 +59,7 @@ def build_meson(build_dir, meson_args, jobs=None, clean=False, verbose=False):
             "-C",
             build_dir,
             "--destdir",
-            install_dir(build_dir),
+            f"../{install_dir}",
         ],
         output=verbose,
     )

--- a/devpy/cmds/_shell.py
+++ b/devpy/cmds/_shell.py
@@ -8,28 +8,22 @@ from .util import run, get_config, set_pythonpath
 
 
 @click.command()
-@click.option(
-    "--build-dir", default="build", help="Build directory; default is `$PWD/build`"
-)
 @click.argument("ipython_args", nargs=-1)
-def ipython(build_dir, ipython_args):
+def ipython(ipython_args):
     """💻 Launch IPython shell with PYTHONPATH set
 
     IPYTHON_ARGS are passed through directly to IPython, e.g.:
 
     ./dev.py ipython -- -i myscript.py
     """
-    p = set_pythonpath(build_dir)
+    p = set_pythonpath()
     print(f'💻 Launching IPython with PYTHONPATH="{p}"')
     run(["ipython", "--ignore-cwd"] + list(ipython_args), replace=True)
 
 
 @click.command()
-@click.option(
-    "--build-dir", default="build", help="Build directory; default is `$PWD/build`"
-)
 @click.argument("shell_args", nargs=-1)
-def shell(build_dir, shell_args=[]):
+def shell(shell_args=[]):
     """💻 Launch shell with PYTHONPATH set
 
     SHELL_ARGS are passed through directly to the shell, e.g.:
@@ -39,7 +33,7 @@ def shell(build_dir, shell_args=[]):
     Ensure that your shell init file (e.g., ~/.zshrc) does not override
     the PYTHONPATH.
     """
-    p = set_pythonpath(build_dir)
+    p = set_pythonpath()
     shell = os.environ.get("SHELL", "sh")
     cmd = [shell] + list(shell_args)
     print(f'💻 Launching shell with PYTHONPATH="{p}"')
@@ -53,14 +47,14 @@ def shell(build_dir, shell_args=[]):
     "--build-dir", default="build", help="Build directory; default is `$PWD/build`"
 )
 @click.argument("python_args", nargs=-1)
-def python(build_dir, python_args):
+def python(python_args):
     """🐍 Launch Python shell with PYTHONPATH set
 
     PYTHON_ARGS are passed through directly to Python, e.g.:
 
     ./dev.py python -- -c 'import sys; print(sys.path)'
     """
-    p = set_pythonpath(build_dir)
+    p = set_pythonpath()
     v = sys.version_info
     if (v.major < 3) or (v.major == 3 and v.minor < 11):
         print("We're sorry, but this feature only works on Python 3.11 and greater 😢")

--- a/devpy/tests/test_util.py
+++ b/devpy/tests/test_util.py
@@ -13,76 +13,88 @@ def make_paths(root, paths):
         os.makedirs(pjoin(root, p.lstrip("/")))
 
 
-def test_path_discovery():
+def test_path_discovery(monkeypatch):
     version = sys.version_info
     X, Y = version.major, version.minor
 
     # With multiple site-packages, choose the one that
     # matches the current Python version
     with tempfile.TemporaryDirectory() as d:
-        build_dir = pjoin(d, "build")
-        install_dir = pjoin(d, "build-install")
-        make_paths(
-            install_dir,
-            [
-                f"/usr/lib64/python{X}.{Y}/site-packages",
-                f"/usr/lib64/python{X}.{Y + 1}/site-packages",
-                f"/usr/lib64/python{X}.{Y + 2}/site-packages",
-            ],
-        )
-        assert normpath(
-            f"/usr/lib64/python{X}.{Y}/site-packages"
-        ) in util.get_site_packages(build_dir)
+        with monkeypatch.context() as m:
+            install_dir = pjoin(d, "build-install")
+            m.setattr(util, "install_dir", install_dir)
+
+            make_paths(
+                install_dir,
+                [
+                    f"/usr/lib64/python{X}.{Y}/site-packages",
+                    f"/usr/lib64/python{X}.{Y + 1}/site-packages",
+                    f"/usr/lib64/python{X}.{Y + 2}/site-packages",
+                ],
+            )
+            assert (
+                normpath(f"/usr/lib64/python{X}.{Y}/site-packages")
+                in util.get_site_packages()
+            )
 
     # Debian uses dist-packages
     with tempfile.TemporaryDirectory() as d:
-        build_dir = pjoin(d, "build")
-        install_dir = pjoin(d, "build-install")
-        make_paths(
-            install_dir,
-            [
-                f"/usr/lib64/python{X}.{Y}/dist-packages",
-            ],
-        )
-        assert normpath(
-            f"/usr/lib64/python{X}.{Y}/dist-packages"
-        ) in util.get_site_packages(build_dir)
+        with monkeypatch.context() as m:
+            install_dir = pjoin(d, "build-install")
+            m.setattr(util, "install_dir", install_dir)
+
+            make_paths(
+                install_dir,
+                [
+                    f"/usr/lib64/python{X}.{Y}/dist-packages",
+                ],
+            )
+            assert (
+                normpath(f"/usr/lib64/python{X}.{Y}/dist-packages")
+                in util.get_site_packages()
+            )
 
     # If there is no version information in site-packages,
     # use whatever site-packages can be found
     with tempfile.TemporaryDirectory() as d:
-        build_dir = pjoin(d, "build")
-        install_dir = pjoin(d, "build-install")
-        make_paths(install_dir, ["/Python3/site-packages"])
-        assert normpath("/Python3/site-packages") in util.get_site_packages(build_dir)
+        with monkeypatch.context() as m:
+            install_dir = pjoin(d, "build-install")
+            m.setattr(util, "install_dir", install_dir)
+
+            make_paths(install_dir, ["/Python3/site-packages"])
+            assert normpath("/Python3/site-packages") in util.get_site_packages()
 
     # Raise if no site-package directory present
     with tempfile.TemporaryDirectory() as d:
-        build_dir = pjoin(d, "build")
-        with pytest.raises(FileNotFoundError):
-            util.get_site_packages(build_dir)
+        with monkeypatch.context() as m:
+            install_dir = pjoin(d, "build-install")
+            m.setattr(util, "install_dir", install_dir)
+
+            with pytest.raises(FileNotFoundError):
+                util.get_site_packages()
 
     # If there are multiple site-package paths, but without version information,
     # refuse the temptation to guess
     with tempfile.TemporaryDirectory() as d:
-        build_dir = pjoin(d, "build")
         install_dir = pjoin(d, "build-install")
         make_paths(
             install_dir, [f"/Python3/x/site-packages", f"/Python3/y/site-packages"]
         )
         with pytest.raises(FileNotFoundError):
-            util.get_site_packages(build_dir)
+            util.get_site_packages()
 
     # Multiple site-package paths found, but none that matches our Python
     with tempfile.TemporaryDirectory() as d:
-        build_dir = pjoin(d, "build")
-        install_dir = pjoin(d, "build-install")
-        make_paths(
-            install_dir,
-            [
-                f"/usr/lib64/python{X}.{Y + 1}/site-packages",
-                f"/usr/lib64/python{X}.{Y + 2}/site-packages",
-            ],
-        )
-        with pytest.raises(FileNotFoundError):
-            util.get_site_packages(build_dir)
+        with monkeypatch.context() as m:
+            install_dir = pjoin(d, "build-install")
+            m.setattr(util, "install_dir", install_dir)
+
+            make_paths(
+                install_dir,
+                [
+                    f"/usr/lib64/python{X}.{Y + 1}/site-packages",
+                    f"/usr/lib64/python{X}.{Y + 2}/site-packages",
+                ],
+            )
+            with pytest.raises(FileNotFoundError):
+                util.get_site_packages()


### PR DESCRIPTION
In order to run the `build` command reliably without arguments, the `--build-dir` flag was removed from all commands.

Closes gh-50